### PR TITLE
feat: Show Custom Cursor

### DIFF
--- a/sasware-fisch.luau
+++ b/sasware-fisch.luau
@@ -1508,11 +1508,7 @@ local Success, Error = pcall(function()
 			end
 		end
 
-		if UI.Library.Toggled then
-			UserInputService.MouseBehavior = Enum.MouseBehavior.Default 
-			UserInputService.MouseIcon = "rbxassetid://2833720882"
-			UserInputService.MouseIconEnabled = not GetToggleValue("ShowCustomCursor")
-		end
+		UserInputService.MouseIconEnabled = not GetToggleValue("ShowCustomCursor") or not UI.Library.Toggled
 
 		if GetToggleValue("NoLocationCC") then
 			Utils.ToggleLocationCC(false)

--- a/sasware-fisch.luau
+++ b/sasware-fisch.luau
@@ -1114,6 +1114,12 @@ local Success, Error = pcall(function()
 
 	Library.ToggleKeybind = UI.Options.MenuKeybind
 
+	MenuGroup:AddToggle("ShowCustomCursor", {
+	        Text = "Custom Cursor",
+	        Default = true,
+	        Callback = function(Value) Library.ShowCustomCursor = Value end
+	})
+
 	ThemeManager:SetLibrary(Library)
 	SaveManager:SetLibrary(Library)
 
@@ -1500,6 +1506,12 @@ local Success, Error = pcall(function()
 					CurrentTool:Activate()
 				end
 			end
+		end
+
+		if GetToggleValue("ShowCustomCursor") and UI.Library.Toggled then
+			UserInputService.MouseBehavior = Enum.MouseBehavior.Default
+			UserInputService.MouseIcon = "rbxassetid://2833720882"
+			UserInputService.MouseIconEnabled = true
 		end
 
 		if GetToggleValue("NoLocationCC") then

--- a/sasware-fisch.luau
+++ b/sasware-fisch.luau
@@ -1508,10 +1508,10 @@ local Success, Error = pcall(function()
 			end
 		end
 
-		if not GetToggleValue("ShowCustomCursor") and UI.Library.Toggled then
-			UserInputService.MouseBehavior = Enum.MouseBehavior.Default
+		if UI.Library.Toggled then
+			UserInputService.MouseBehavior = Enum.MouseBehavior.Default 
 			UserInputService.MouseIcon = "rbxassetid://2833720882"
-			UserInputService.MouseIconEnabled = true
+			UserInputService.MouseIconEnabled = not GetToggleValue("ShowCustomCursor")
 		end
 
 		if GetToggleValue("NoLocationCC") then

--- a/sasware-fisch.luau
+++ b/sasware-fisch.luau
@@ -1120,6 +1120,8 @@ local Success, Error = pcall(function()
 	        Callback = function(Value) Library.ShowCustomCursor = Value end
 	})
 
+	Library.ShowCustomCursor = UI.Toggles.ShowCustomCursor.Value
+
 	ThemeManager:SetLibrary(Library)
 	SaveManager:SetLibrary(Library)
 

--- a/sasware-fisch.luau
+++ b/sasware-fisch.luau
@@ -1508,7 +1508,7 @@ local Success, Error = pcall(function()
 			end
 		end
 
-		if GetToggleValue("ShowCustomCursor") and UI.Library.Toggled then
+		if not GetToggleValue("ShowCustomCursor") and UI.Library.Toggled then
 			UserInputService.MouseBehavior = Enum.MouseBehavior.Default
 			UserInputService.MouseIcon = "rbxassetid://2833720882"
 			UserInputService.MouseIconEnabled = true


### PR DESCRIPTION
Add a option to enable or disable custom cursor due to misalignement bug that sometimes occurs when using drawing library cursor. Also better for externals as their drawing libraries cant fill in triangles.